### PR TITLE
fix: do not include node_modules in the Node bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "node": ">=16.x"
       },
       "optimize": true,
-      "includeNodeModules": true,
+      "includeNodeModules": false,
       "outputFormat": "esmodule",
       "isLibrary": true
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
         "node": ">=12.x"
       },
       "optimize": true,
-      "includeNodeModules": true,
+      "includeNodeModules": {
+        "escape-string-regexp": true,
+        "replace-ext": false
+      },
       "outputFormat": "commonjs",
       "isLibrary": true
     },


### PR DESCRIPTION
The user of the library can bundle the node_modules if they want to. This separation allows more flexibility later